### PR TITLE
Typehint against the interface, not the implementation

### DIFF
--- a/src/Twig/CoreExtension.php
+++ b/src/Twig/CoreExtension.php
@@ -2,13 +2,13 @@
 
 namespace Gitiki\Twig;
 
-use Silex\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class CoreExtension extends \Twig_Extension
 {
     protected $translator;
 
-    public function __construct(Translator $translator)
+    public function __construct(TranslatorInterface $translator)
     {
         $this->translator = $translator;
     }


### PR DESCRIPTION
This would make the extension compatible with cases where the translator is not the Silex one directly but a wrapped one (the WebProfiler service provider does not yet support profiling the translator, but this may come in the future)
